### PR TITLE
Redirect unauthorised users to CDS subscription page

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -17,6 +17,7 @@
 package config
 
 import com.google.inject.{Inject, Singleton}
+import models.EnrolmentConfig
 import play.api.Configuration
 import play.api.i18n.Lang
 import play.api.mvc.RequestHeader
@@ -37,6 +38,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
   val loginUrl: String         = configuration.get[String]("urls.login")
   val loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
   val signOutUrl: String       = configuration.get[String]("urls.signOut")
+  val cdsSubscribeUrl: String       = configuration.get[String]("urls.cdsSubscribeUrl")
 
   private val exitSurveyBaseUrl: String = configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
   val exitSurveyUrl: String             = s"$exitSurveyBaseUrl/feedback/trade-reporting-extracts-frontend"
@@ -56,5 +58,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
 
   lazy val tradeReportingExtractsApi: String = servicesConfig.baseUrl("trade-reporting-extracts") +
     configuration.get[String]("microservice.services.trade-reporting-extracts.context")
+
+  val cdsEnrolmentIdentifier: EnrolmentConfig = configuration.get[EnrolmentConfig]("enrolment-config")
 
 }

--- a/app/controllers/UnauthorisedController.scala
+++ b/app/controllers/UnauthorisedController.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import config.FrontendAppConfig
 import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -24,11 +25,12 @@ import views.html.UnauthorisedView
 
 class UnauthorisedController @Inject() (
   val controllerComponents: MessagesControllerComponents,
+  config: FrontendAppConfig,
   view: UnauthorisedView
 ) extends FrontendBaseController
     with I18nSupport {
 
   def onPageLoad(): Action[AnyContent] = Action { implicit request =>
-    Ok(view())
+    Ok(view(config.cdsSubscribeUrl))
   }
 }

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -20,9 +20,10 @@ import com.google.inject.Inject
 import config.FrontendAppConfig
 import controllers.routes
 import models.requests.IdentifierRequest
-import play.api.mvc.Results._
-import play.api.mvc._
-import uk.gov.hmrc.auth.core._
+import play.api.Logging
+import play.api.mvc.Results.*
+import play.api.mvc.*
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.http.{HeaderCarrier, UnauthorizedException}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
@@ -39,13 +40,16 @@ class AuthenticatedIdentifierAction @Inject() (
   val parser: BodyParsers.Default
 )(implicit val executionContext: ExecutionContext)
     extends IdentifierAction
-    with AuthorisedFunctions {
+    with AuthorisedFunctions
+    with Logging {
 
   override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
 
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+    val predicates                 =
+      Enrolment(config.cdsEnrolmentIdentifier.key) and (AffinityGroup.Organisation or AffinityGroup.Individual)
 
-    authorised().retrieve(Retrievals.internalId) {
+    authorised(predicates).retrieve(Retrievals.internalId) {
       _.map { internalId =>
         block(IdentifierRequest(request, internalId))
       }.getOrElse(throw new UnauthorizedException("Unable to retrieve internal Id"))

--- a/app/models/EnrolmentConfig.scala
+++ b/app/models/EnrolmentConfig.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.{ConfigLoader, Configuration}
+
+case class EnrolmentConfig(key: String, identifier: String)
+
+object EnrolmentConfig {
+
+  implicit lazy val configLoader: ConfigLoader[EnrolmentConfig] = ConfigLoader { config => prefix =>
+    val enrolmentConfig = Configuration(config).get[Configuration](prefix)
+    val key             = enrolmentConfig.get[String]("enrolment-key")
+    val id              = enrolmentConfig.get[String]("enrolment-identifier")
+
+    EnrolmentConfig(key, id)
+  }
+}

--- a/app/views/UnauthorisedView.scala.html
+++ b/app/views/UnauthorisedView.scala.html
@@ -18,14 +18,28 @@
     layout: templates.Layout
 )
 
-@()(implicit request: Request[_], messages: Messages)
+@(cdsSubscribeUrl: String)(implicit request: Request[_], messages: Messages)
 
 @layout(
     pageTitle = titleNoForm(messages("unauthorised.title")),
     timeout   = false
 ) {
 
-    <h1 class="govuk-heading-xl">@messages("unauthorised.heading")</h1>
+<h1 class="govuk-heading-l">@messages("unauthorisedCdsEnrolment.heading")</h1>
 
-    <p class="govuk-body">@messages("unauthorised.guidance")</p>
+<p class="govuk-body">@messages("unauthorisedCdsEnrolment.p1")</p>
+
+<p class="govuk-body">
+    <a href="@cdsSubscribeUrl" rel="noreferrer noopener" target="_blank" class=govuk-link>
+        @messages("unauthorisedCdsEnrolment.cdsLink")
+    </a>
+</p>
+
+<p class="govuk-body">
+    @messages("unauthorisedCdsEnrolment.p2.part1")
+    <a href="@routes.ContactDetailsController.onPageLoad().url" class="govuk-link">
+        @messages("unauthorisedCdsEnrolment.p2.linkText")
+    </a>
+    @messages("unauthorisedCdsEnrolment.p2.part2")
+</p>
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -75,6 +75,7 @@ urls {
   login         = "http://localhost:9949/auth-login-stub/gg-sign-in"
   loginContinue = "http://localhost:2102/request-customs-declaration-data/dashboard"
   signOut       = "http://localhost:9025/gg/sign-out"
+  cdsSubscribeUrl = "https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service"
 }
 
 host = "http://localhost:2102"
@@ -89,4 +90,9 @@ tracking-consent-frontend {
 
 features {
   welsh-translation: true
+}
+
+enrolment-config {
+    enrolment-key = "HMRC-CUS-ORG"
+    enrolment-identifier = "EORINumber"
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -118,3 +118,11 @@ contactDetails.name = Name
 contactDetails.eoriNumber = EORI number
 contactDetails.address = Address
 
+unauthorisedCdsEnrolment.title = There is a problem
+unauthorisedCdsEnrolment.heading = There is a problem
+unauthorisedCdsEnrolment.p1 = The details signed in are not subscribed to the Customs Declaration Service (CDS).
+unauthorisedCdsEnrolment.cdsLink = You must be subscribed to CDS before you can use Trade Reporting Extracts (opens in new tab).
+unauthorisedCdsEnrolment.p2.part1 = If you are subscribed to CDS,
+unauthorisedCdsEnrolment.p2.linkText = sign out
+unauthorisedCdsEnrolment.p2.part2 = and sign in with the correct details.
+

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,12 +2,12 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.9.0"
+  private val bootstrapVersion = "9.11.0"
   private val hmrcMongoVersion = "2.5.0"
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "11.11.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "11.12.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % hmrcMongoVersion
   )

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -17,8 +17,9 @@
 package controllers
 
 import base.SpecBase
+import config.FrontendAppConfig
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import views.html.UnauthorisedView
 
 class UnauthorisedControllerSpec extends SpecBase {
@@ -34,10 +35,11 @@ class UnauthorisedControllerSpec extends SpecBase {
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[UnauthorisedView]
+        val view   = application.injector.instanceOf[UnauthorisedView]
+        val config = application.injector.instanceOf[FrontendAppConfig]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view()(request, messages(application)).toString
+        contentAsString(result) mustEqual view(config.cdsSubscribeUrl)(request, messages(application)).toString
       }
     }
   }


### PR DESCRIPTION
1) Check Authorisation for CDS 
2) If user is not authorised, redirect the page to an error page with CDS subscription page link 
3) Default unauthorised page view has been modified to include CDS subscription link 