### PR TITLE
TRE-544 Hide additional email page when notifications are disabled

### DIFF
--- a/app/navigation/ReportNavigator.scala
+++ b/app/navigation/ReportNavigator.scala
@@ -37,19 +37,26 @@ class ReportNavigator @Inject() (appConfig: FrontendAppConfig) extends Navigator
     case CustomRequestStartDatePage             =>
       navigateTo(controllers.report.routes.CustomRequestEndDateController.onPageLoad(NormalMode))
     case CustomRequestEndDatePage               => navigateTo(controllers.report.routes.ReportNameController.onPageLoad(NormalMode))
-    case ReportNamePage                         => navigateTo(controllers.report.routes.MaybeAdditionalEmailController.onPageLoad(NormalMode))
-    case MaybeAdditionalEmailPage               =>
+
+    case ReportNamePage =>
+      if (appConfig.notificationsEnabled) {
+        navigateTo(controllers.report.routes.MaybeAdditionalEmailController.onPageLoad(NormalMode))
+      } else {
+        navigateTo(controllers.report.routes.CheckYourAnswersController.onPageLoad())
+      }
+
+    case MaybeAdditionalEmailPage =>
       conditionalNavigate(
         hasAdditionalEmailRequest,
         controllers.report.routes.EmailSelectionController.onPageLoad(NormalMode)
       )
-    case EmailSelectionPage                     =>
+    case EmailSelectionPage       =>
       conditionalNavigate(
         isAddNewEmail,
         controllers.report.routes.NewEmailNotificationController.onPageLoad(NormalMode)
       )
-    case NewEmailNotificationPage               => navigateTo(controllers.report.routes.CheckYourAnswersController.onPageLoad())
-    case CheckYourAnswersPage                   => navigateTo(controllers.report.routes.RequestConfirmationController.onPageLoad())
+    case NewEmailNotificationPage => navigateTo(controllers.report.routes.CheckYourAnswersController.onPageLoad())
+    case CheckYourAnswersPage     => navigateTo(controllers.report.routes.RequestConfirmationController.onPageLoad())
   }
 
   private def navigateTo(call: => Call): UserAnswers => Call = _ => call

--- a/test/navigation/ReportNavigatorSpec.scala
+++ b/test/navigation/ReportNavigatorSpec.scala
@@ -21,6 +21,7 @@ import config.FrontendAppConfig
 import models.*
 import models.report.*
 import org.mockito.Mockito.when
+import org.scalatest.matchers.should.Matchers.should
 import org.scalatestplus.mockito.MockitoSugar.mock
 import pages.*
 import pages.report.*
@@ -192,16 +193,39 @@ class ReportNavigatorSpec extends SpecBase {
         checkNavigation(result, "/date-rage")
       }
 
-      "ReportNamePage must navigate to MaybeAdditionalEmail" in {
+      "ReportNamePage navigation" - {
 
-        val ua = emptyUserAnswers
-          .set(ReportNamePage, "name")
-          .success
-          .value
+        "navigate to CheckYourAnswersPage when notificationsEnabled is false" in {
+          val mockAppConfig = mock[FrontendAppConfig]
+          when(mockAppConfig.notificationsEnabled).thenReturn(false)
 
-        val result = navigator.nextPage(ReportNamePage, NormalMode, ua).url
+          val navigator = new ReportNavigator(mockAppConfig)
 
-        checkNavigation(result, "/choose-email-address")
+          val ua = emptyUserAnswers
+            .set(ReportNamePage, "name")
+            .success
+            .value
+
+          val result = navigator.nextPage(ReportNamePage, NormalMode, ua).url
+
+          checkNavigation(result, "/check-your-answers")
+        }
+
+        "navigate to MaybeAdditionalEmailPage when notificationsEnabled is true" in {
+          val mockAppConfig = mock[FrontendAppConfig]
+          when(mockAppConfig.notificationsEnabled).thenReturn(true)
+
+          val navigator = new ReportNavigator(mockAppConfig)
+
+          val ua = emptyUserAnswers
+            .set(ReportNamePage, "name")
+            .success
+            .value
+
+          val result = navigator.nextPage(ReportNamePage, NormalMode, ua).url
+
+          checkNavigation(result, "/choose-email-address")
+        }
       }
 
       "ReportDateRangePage" - {


### PR DESCRIPTION
When the notificationsEnabled flag is set to false, user will be navigated to the check your answers page after the reportName Page. 

If the flag is set to true, user will be navigated to mayBeAdditionalEmails Page as usual. 