### PR TITLE
TRE-606 Check your answers page corrections

### DIFF
--- a/app/viewmodels/checkAnswers/report/MaybeAdditionalEmailSummary.scala
+++ b/app/viewmodels/checkAnswers/report/MaybeAdditionalEmailSummary.scala
@@ -16,12 +16,10 @@
 
 package viewmodels.checkAnswers.report
 
-import models.report.EmailSelection
 import models.{CheckMode, UserAnswers}
-import pages.report.{EmailSelectionPage, MaybeAdditionalEmailPage, NewEmailNotificationPage}
+import pages.report.MaybeAdditionalEmailPage
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
@@ -29,38 +27,18 @@ import viewmodels.implicits.*
 object MaybeAdditionalEmailSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(MaybeAdditionalEmailPage).getOrElse(false) match {
-      case true  =>
-        answers.get(EmailSelectionPage).map { answer =>
+    answers.get(MaybeAdditionalEmailPage).map { answer =>
+      val displayValue = if (answer) messages("site.yes") else messages("site.no")
 
-          val value = ValueViewModel(
-            HtmlContent(
-              answer
-                .map {
-                  case EmailSelection.Email3 =>
-                    answers
-                      .get(NewEmailNotificationPage)
-                      .map(email => HtmlFormat.escape(email).toString)
-                      .getOrElse("")
-
-                  case email => HtmlFormat.escape(messages(s"emailSelection.$email")).toString
-                }
-                .mkString(",<br>")
-            )
-          )
-
-          SummaryListRowViewModel(
-            key = "emailSelection.checkYourAnswersLabel",
-            value = value,
-            actions = Seq(
-              ActionItemViewModel(
-                "site.change",
-                controllers.report.routes.MaybeAdditionalEmailController.onPageLoad(CheckMode).url
-              )
-                .withVisuallyHiddenText(messages("emailSelection.change.hidden"))
-            )
-          )
-        }
-      case false => None
+      SummaryListRowViewModel(
+        key = "maybeAdditionalEmail.checkYourAnswersLabel",
+        value = ValueViewModel(displayValue),
+        actions = Seq(
+          ActionItemViewModel(
+            "site.change",
+            controllers.report.routes.MaybeAdditionalEmailController.onPageLoad(CheckMode).url
+          ).withVisuallyHiddenText(messages("maybeAdditionalEmail.change.hidden"))
+        )
+      )
     }
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -216,7 +216,7 @@ emailSelection.hint = Select all that apply
 
 maybeAdditionalEmail.title = Do you want to add another email for notifications?
 maybeAdditionalEmail.heading = Do you want to add another email for notifications?
-maybeAdditionalEmail.checkYourAnswersLabel = Notification email
+maybeAdditionalEmail.checkYourAnswersLabel = Do you want to add another email for notifications?
 maybeAdditionalEmail.error.required = Select yes if you want to add another email for notifications
 maybeAdditionalEmail.change.hidden = if you want to add another email for notifications
 
@@ -237,7 +237,7 @@ requestConfirmation.feedbackDuration = (takes 30 seconds)
 
 newEmailNotification.title = Enter a new email address to receive notifications
 newEmailNotification.heading = Enter a new email address to receive notifications
-newEmailNotification.checkYourAnswersLabel = Notification email
+newEmailNotification.checkYourAnswersLabel = New notification email
 newEmailNotification.error.required = Enter a new email address to receive notifications
 newEmailNotification.error.length =  Enter a new email address not greater than 100 characters
 newEmailNotification.error.invalidFormat =  Enter a new email address in the correct format, like name@example.com

--- a/test/viewmodels/checkAnswers/report/MaybeAdditionalEmailSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/report/MaybeAdditionalEmailSummarySpec.scala
@@ -17,16 +17,11 @@
 package viewmodels.checkAnswers.report
 
 import base.SpecBase
+import models.UserAnswers
 import models.report.EmailSelection
-import models.{CheckMode, UserAnswers}
 import pages.report.{EmailSelectionPage, MaybeAdditionalEmailPage, NewEmailNotificationPage}
 import play.api.i18n.Messages
 import play.api.test.Helpers.stubMessages
-import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Actions, SummaryListRow}
-import viewmodels.govuk.summarylist.*
-import viewmodels.implicits.*
 
 class MaybeAdditionalEmailSummarySpec extends SpecBase {
 
@@ -34,7 +29,7 @@ class MaybeAdditionalEmailSummarySpec extends SpecBase {
 
   "MaybeAdditionalEmailSummary.row" - {
 
-    "must return a SummaryListRow when an answer is present" in {
+    "must return a SummaryListRow with 'Yes' when the answer is true" in {
       val initialAnswers = UserAnswers("id")
 
       val updatedAnswers = initialAnswers
@@ -44,15 +39,22 @@ class MaybeAdditionalEmailSummarySpec extends SpecBase {
 
       val result = MaybeAdditionalEmailSummary.row(updatedAnswers.success.value)
 
-      assert(result.toString contains "test@gmail.com")
+      result mustBe defined
+      result.get.value.content.toString must include(messages("site.yes"))
     }
 
-    "must return None when no answer is present" in {
-      val answers = UserAnswers("id")
+    "must return a SummaryListRow with 'No' when the answer is false" in {
+      val initialAnswers = UserAnswers("id")
 
-      val result = MaybeAdditionalEmailSummary.row(answers)
+      val updatedAnswers = initialAnswers
+        .set(MaybeAdditionalEmailPage, false)
+        .flatMap(_.set(EmailSelectionPage, Set(EmailSelection.Email2)))
+        .flatMap(_.set(NewEmailNotificationPage, "another@example.com"))
 
-      result mustBe None
+      val result = MaybeAdditionalEmailSummary.row(updatedAnswers.success.value)
+
+      result mustBe defined
+      result.get.value.content.toString must include(messages("site.no"))
     }
   }
 }


### PR DESCRIPTION
1. Hide report type row from check your answers page when user selects Export reports 
2. Add new field for additional email decision page on the check your answers page.